### PR TITLE
Add DataRepo and Koin use case

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 26
@@ -22,6 +23,8 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "io.insert-koin:koin-android:3.4.0"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.gushakir.hs.gushakir">
 
     <application
+        android:name=".MyApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/gushakir/hs/gushakir/MainActivity.java
+++ b/app/src/main/java/com/gushakir/hs/gushakir/MainActivity.java
@@ -14,6 +14,10 @@ import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.GridLayout;
 import android.widget.LinearLayout;
+import android.util.Log;
+
+import com.gushakir.hs.gushakir.presentation.DataViewModel;
+import org.koin.java.KoinJavaComponent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,8 +41,12 @@ public class MainActivity extends FragmentActivity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		GameUtils.hideSystemUI(getWindow());
-		setContentView(R.layout.activity_main);
-		getWindow().getDecorView().setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
+                setContentView(R.layout.activity_main);
+
+                DataViewModel viewModel = KoinJavaComponent.get(DataViewModel.class);
+                Log.d("MainActivity", "Loaded data: " + viewModel.loadData());
+
+                getWindow().getDecorView().setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
 			@Override
 			public void onSystemUiVisibilityChange(int i) {
 				GameUtils.hideSystemUI(getWindow());

--- a/app/src/main/java/com/gushakir/hs/gushakir/MyApplication.kt
+++ b/app/src/main/java/com/gushakir/hs/gushakir/MyApplication.kt
@@ -1,0 +1,16 @@
+package com.gushakir.hs.gushakir
+
+import android.app.Application
+import com.gushakir.hs.gushakir.di.appModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
+
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        startKoin {
+            androidContext(this@MyApplication)
+            modules(appModule)
+        }
+    }
+}

--- a/app/src/main/java/com/gushakir/hs/gushakir/data/DataRepo.kt
+++ b/app/src/main/java/com/gushakir/hs/gushakir/data/DataRepo.kt
@@ -1,0 +1,5 @@
+package com.gushakir.hs.gushakir.data
+
+interface DataRepo {
+    fun getData(): String
+}

--- a/app/src/main/java/com/gushakir/hs/gushakir/data/DataRepoImpl.kt
+++ b/app/src/main/java/com/gushakir/hs/gushakir/data/DataRepoImpl.kt
@@ -1,0 +1,7 @@
+package com.gushakir.hs.gushakir.data
+
+class DataRepoImpl : DataRepo {
+    override fun getData(): String {
+        return "sample data"
+    }
+}

--- a/app/src/main/java/com/gushakir/hs/gushakir/di/AppModule.kt
+++ b/app/src/main/java/com/gushakir/hs/gushakir/di/AppModule.kt
@@ -1,0 +1,13 @@
+package com.gushakir.hs.gushakir.di
+
+import com.gushakir.hs.gushakir.data.DataRepo
+import com.gushakir.hs.gushakir.data.DataRepoImpl
+import com.gushakir.hs.gushakir.domain.GetDataUseCase
+import com.gushakir.hs.gushakir.presentation.DataViewModel
+import org.koin.dsl.module
+
+val appModule = module {
+    single<DataRepo> { DataRepoImpl() }
+    factory { GetDataUseCase(get()) }
+    factory { DataViewModel(get()) }
+}

--- a/app/src/main/java/com/gushakir/hs/gushakir/domain/GetDataUseCase.kt
+++ b/app/src/main/java/com/gushakir/hs/gushakir/domain/GetDataUseCase.kt
@@ -1,0 +1,7 @@
+package com.gushakir.hs.gushakir.domain
+
+import com.gushakir.hs.gushakir.data.DataRepo
+
+class GetDataUseCase(private val repo: DataRepo) {
+    operator fun invoke(): String = repo.getData()
+}

--- a/app/src/main/java/com/gushakir/hs/gushakir/presentation/DataViewModel.kt
+++ b/app/src/main/java/com/gushakir/hs/gushakir/presentation/DataViewModel.kt
@@ -1,0 +1,9 @@
+package com.gushakir.hs.gushakir.presentation
+
+import androidx.lifecycle.ViewModel
+import com.gushakir.hs.gushakir.domain.GetDataUseCase
+
+class DataViewModel(private val getDataUseCase: GetDataUseCase) : ViewModel() {
+    fun loadData(): String = getDataUseCase()
+}
+

--- a/app/src/test/java/com/gushakir/hs/gushakir/DataRepoTest.kt
+++ b/app/src/test/java/com/gushakir/hs/gushakir/DataRepoTest.kt
@@ -1,0 +1,13 @@
+package com.gushakir.hs.gushakir
+
+import com.gushakir.hs.gushakir.data.DataRepoImpl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DataRepoTest {
+    @Test
+    fun testGetData() {
+        val repo = DataRepoImpl()
+        assertEquals("sample data", repo.getData())
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.kotlin_version = '1.6.21'
     
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -19,6 +22,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
## Summary
- add Kotlin support with Koin setup
- implement `DataRepo` and `DataRepoImpl`
- add `GetDataUseCase`
- wire dependencies via `appModule` and start Koin in `MyApplication`
- update manifest and add unit test
- inject new `DataViewModel` into `MainActivity`

## Testing
- `./gradlew test --no-daemon` *(fails: Could not determine java version from '21.0.7')*

------
https://chatgpt.com/codex/tasks/task_e_6842cf9a75388320a553faacbdf08c05